### PR TITLE
Include the step to add 'deployers' within Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Interact with the Marathon API for your Mesos cluster
 
 ## Installation
 
+Within your Lita setup, make a new authorized group called 'deployers'.
+
+As an admin using the Slack adaptor for example:
+
+```
+lita auth add <user.id/user.name> deployers
+```
+
 Add lita-marathon to your Lita instance's Gemfile:
 
 ``` ruby


### PR DESCRIPTION
Had to have a slight dig to figure out the configuration, would be awesome if it was a step included within the Readme. 

Useful plugin, thanks for the creation!